### PR TITLE
React-Native 0.65 compatibility / Forward-port Accessibility to react-native 0.60 API

### DIFF
--- a/src/native-common/Accessibility.ts
+++ b/src/native-common/Accessibility.ts
@@ -25,24 +25,24 @@ export class Accessibility extends CommonAccessibility {
     constructor() {
         super();
 
-        let initialStateChanged = false;
+        let initialScreenReaderState = false;
 
         // Some versions of RN don't support this interface.
         if (RN.AccessibilityInfo) {
             // Subscribe to an event to get notified when screen reader is enabled or disabled.
-            RN.AccessibilityInfo.addEventListener('change', (isEnabled: boolean) => {
-                initialStateChanged = true;
+            RN.AccessibilityInfo.addEventListener('screenReaderChanged', (isEnabled: boolean) => {
+                initialScreenReaderState = true;
                 this._updateScreenReaderStatus(isEnabled);
             });
 
             // Fetch initial state.
-            RN.AccessibilityInfo.fetch().then(isEnabled => {
-                if (!initialStateChanged) {
+            RN.AccessibilityInfo.isScreenReaderEnabled().then(isEnabled => {
+                if (!initialScreenReaderState) {
                     this._updateScreenReaderStatus(isEnabled);
                 }
             }).catch(err => {
                 if (AppConfig.isDevelopmentMode()) {
-                    console.error('Accessibility: RN.AccessibilityInfo.fetch failed');
+                    console.error('Accessibility: RN.AccessibilityInfo.isScreenReaderEnabled failed');
                 }
             });
         }


### PR DESCRIPTION
React-Native 0.59 -> 0.60 changed a lot of the AccessibilityInfo API, and this does a straight forward-port of existing functionality (screen reader status detection) to the new API.

Here is the related PR https://github.com/facebook/react-native-website/pull/835

And the doc with new APIs https://facebook.github.io/react-native/docs/accessibilityinfo

This depends on the PR here for types I believe https://github.com/DefinitelyTyped/DefinitelyTyped/pull/37486

There is an opportunity to also expand API coverage to cover the other new accessibility features react-native exposes but if this is desired it might be best to do it separately? Additionally the majority are iOS-specific so if I proposed that change I'd need some guidance.

Fixes https://github.com/microsoft/reactxp/issues/1319