### PR TITLE
useNativeDriver is required field

### DIFF
--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -1091,7 +1091,7 @@ export namespace Animated {
     }
 
     export interface AnimationConfig {
-        useNativeDriver?: boolean;
+        useNativeDriver: boolean;
         isInteraction?: boolean;
     }
 

--- a/src/native-common/Button.tsx
+++ b/src/native-common/Button.tsx
@@ -376,6 +376,7 @@ export class Button extends ButtonBase {
                 toValue: value,
                 duration: duration,
                 easing: Animated.Easing.InOut(),
+                useNativeDriver: true
             },
         ).start();
     }

--- a/src/native-common/View.tsx
+++ b/src/native-common/View.tsx
@@ -440,6 +440,7 @@ export class View extends ViewBase<RX.Types.ViewProps, RX.Types.Stateless, RN.Vi
                 toValue: value,
                 duration: duration,
                 easing: Animated.Easing.InOut(),
+                useNativeDriver: true
             },
         ).start();
     }


### PR DESCRIPTION
Updated react native shows warning if any animation timing didn't have `useNativeDriver` defined. 

Made that field required in types and also updated button and view animation component with it.